### PR TITLE
removed the unnecessary space between "number s"

### DIFF
--- a/guide/english/javascript/numbers/index.md
+++ b/guide/english/javascript/numbers/index.md
@@ -4,7 +4,7 @@ title: Numbers
 ## Numbers
 
 
-The implementation of JavaScript's `number`s is based on the `IEEE 754` standard, often called "floating-point." 
+The implementation of JavaScript's `numbers is based on the `IEEE 754` standard, often called "floating-point." 
 
 <a href='https://en.wikipedia.org/wiki/IEEE_754' target='_blank' rel='nofollow'>IEEE 754 Wikipedia Link</a>
 <br>


### PR DESCRIPTION
prev: The implementation of JavaScript's `number s is based on the `IEEE 754` standard, often called "floating-point." 
my changes: The implementation of JavaScript's `numbers is based on the `IEEE 754` standard, often called "floating-point."

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ x] My pull request targets the `master` branch of freeCodeCamp.
- [ x] None of my changes are plagiarized from another source without proper attribution.
- [ x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
